### PR TITLE
query input parameter support list type

### DIFF
--- a/graphql-java-runtime/src/main/java/com/graphql_java_generator/client/request/InputParameter.java
+++ b/graphql-java-runtime/src/main/java/com/graphql_java_generator/client/request/InputParameter.java
@@ -3,6 +3,8 @@
  */
 package com.graphql_java_generator.client.request;
 
+import java.util.List;
+
 /**
  * Contains a parameter, to be sent to a query (mutation...).
  * 
@@ -45,23 +47,46 @@ public class InputParameter {
 	 * @return
 	 */
 	public String getValueForGraphqlQuery() {
-		if (value == null) {
+		return this.getValueForGraphqlQuery(this.value);
+	}
+
+	private String getValueForGraphqlQuery(Object val) {
+		if (val == null) {
 			return null;
+		} else if (val instanceof String) {
+			return getStringValue((String) val);
+		} else if (val instanceof java.util.List) {
+			return getListValue((List) val);
 		} else {
-			switch (value.getClass().getName()) {
-			case "java.lang.String":
-				return getStringValue((String) value);
-			default:
-				return value.toString();
-			}
+			return val.toString();
 		}
 	}
 
 	/**
 	 * @return
 	 */
-	private static String getStringValue(String str) {
+	private String getStringValue(String str) {
 		return "\\\"" + str.replace("\"", "\\\"") + "\\\"";
+	}
+
+	/**
+	 * @param lst
+	 * @return
+	 */
+	private String getListValue(List lst) {
+		if (lst == null) {
+			return null;
+		} else {
+			StringBuilder result = new StringBuilder("[");
+			for (int index = 0; index < lst.size(); index ++) {
+				Object obj = lst.get(index);
+				result.append(this.getValueForGraphqlQuery(obj));
+				if (index < lst.size() - 1) {
+					result.append(",");
+				}
+			}
+			return result.append("]").toString();
+		}
 	}
 
 }

--- a/graphql-maven-plugin-logic/src/main/resources/templates/client_query_mutation_subscription_type.vm.java
+++ b/graphql-maven-plugin-logic/src/main/resources/templates/client_query_mutation_subscription_type.vm.java
@@ -1,5 +1,6 @@
 package ${package};
-#macro(inputParams)#foreach ($inputParameter in $field.inputParameters), ${inputParameter.type.classSimpleName} ${inputParameter.name}#end#end
+#macro(inputParams)#foreach ($inputParameter in $field.inputParameters), #if(${inputParameter.list})List<#end${inputParameter.type.classSimpleName}#if(${inputParameter.list})>#end ${inputParameter.name}#end#end
+
 #macro(inputValues)#foreach ($inputParameter in $field.inputParameters), ${inputParameter.name}#end#end
 
 import java.io.IOException;

--- a/graphql-maven-plugin-logic/src/main/resources/templates/client_query_mutation_subscription_type.vm.java
+++ b/graphql-maven-plugin-logic/src/main/resources/templates/client_query_mutation_subscription_type.vm.java
@@ -118,7 +118,9 @@ public class ${object.name} {
 		// InputParameters
 		List<InputParameter> parameters = new ArrayList<>();
 #foreach ($inputParameter in $field.inputParameters)
-		parameters.add(new InputParameter("${inputParameter.name}", ${inputParameter.name}));
+		if (${inputParameter.name} != null){
+			parameters.add(new InputParameter("${inputParameter.name}",${inputParameter.name}));
+		}
 #end
 
 		if (!${field.type.classSimpleName}.class.equals(objectResponse.getFieldClass())) {


### PR DESCRIPTION
Currently, if the query parameter type is list, the generated code is incorrect