### PR TITLE
Input type custom scalars

### DIFF
--- a/graphql-java-runtime/src/main/java/com/graphql_java_generator/client/GraphqlClientUtils.java
+++ b/graphql-java-runtime/src/main/java/com/graphql_java_generator/client/GraphqlClientUtils.java
@@ -15,6 +15,7 @@ import java.util.regex.Pattern;
 
 import org.springframework.stereotype.Component;
 
+import com.graphql_java_generator.CustomScalarRegistryImpl;
 import com.graphql_java_generator.GraphqlUtils;
 import com.graphql_java_generator.annotation.GraphQLCustomScalar;
 import com.graphql_java_generator.annotation.GraphQLNonScalar;
@@ -22,6 +23,8 @@ import com.graphql_java_generator.annotation.GraphQLScalar;
 import com.graphql_java_generator.client.request.ObjectResponse;
 import com.graphql_java_generator.exception.GraphQLRequestExecutionException;
 import com.graphql_java_generator.exception.GraphQLRequestPreparationException;
+
+import graphql.schema.GraphQLScalarType;
 
 /**
  * @author EtienneSF
@@ -309,5 +312,30 @@ public class GraphqlClientUtils {
 
 		return map;
 	}
+
+	/**
+	 * This method retrieves the {@link GraphQLScalarType} for a custom scalar field or method.
+	 * {@link GraphQLScalar} is used in generated InputType and response type POJOs and
+	 * {@link GraphQLCustomScalar} is used in some legacy generated response type POJOs.
+	 *
+	 * @param fieldOrMethod The field or method of the generated POJO class
+	 * @return the {@link GraphQLScalarType}
+	 */
+	public GraphQLScalarType getGraphQLCustomScalarType( AccessibleObject fieldOrMethod ) {
+		String graphQLTypeName;
+		if (fieldOrMethod.getAnnotation(GraphQLCustomScalar.class) != null) {
+			graphQLTypeName = fieldOrMethod.getAnnotation(GraphQLCustomScalar.class).graphQLTypeName();
+		} else if (fieldOrMethod.getAnnotation(GraphQLScalar.class) != null) {
+			graphQLTypeName = fieldOrMethod.getAnnotation( GraphQLScalar.class ).graphQLTypeName();
+		} else {
+			graphQLTypeName = null;
+		}
+		if (graphQLTypeName != null) {
+			return CustomScalarRegistryImpl.customScalarRegistry.getGraphQLScalarType(graphQLTypeName);
+		} else {
+			return null;
+		}
+	}
+
 
 }

--- a/graphql-java-runtime/src/main/java/com/graphql_java_generator/client/request/InputParameter.java
+++ b/graphql-java-runtime/src/main/java/com/graphql_java_generator/client/request/InputParameter.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 
 import com.graphql_java_generator.GraphqlUtils;
 import com.graphql_java_generator.annotation.GraphQLInputType;
+import com.graphql_java_generator.client.GraphqlClientUtils;
 import com.graphql_java_generator.client.QueryExecutorImpl;
 import com.graphql_java_generator.exception.GraphQLRequestExecutionException;
 
@@ -31,6 +32,9 @@ public class InputParameter {
 
 	/** A utility class, that's used here */
 	private static GraphqlUtils graphqlUtils = new GraphqlUtils();
+
+	/** A utility class, that's used here */
+	private static GraphqlClientUtils graphqlClientUtils = new GraphqlClientUtils();
 
 	/** The parameter name, as defined in the GraphQL schema */
 	final String name;
@@ -186,9 +190,9 @@ public class InputParameter {
 			if (bindVariables == null || !bindVariables.keySet().contains(this.bindParameterName))
 				return null;
 			else
-				return this.getValueForGraphqlQuery(bindVariables.get(this.bindParameterName));
+				return this.getValueForGraphqlQuery(bindVariables.get(this.bindParameterName), graphQLScalarType);
 		} else
-			return this.getValueForGraphqlQuery(this.value);
+			return this.getValueForGraphqlQuery(this.value, graphQLScalarType);
 
 	}
 
@@ -202,11 +206,11 @@ public class InputParameter {
 	 * @return
 	 * @throws GraphQLRequestExecutionException
 	 */
-	String getValueForGraphqlQuery(Object val) throws GraphQLRequestExecutionException {
+	String getValueForGraphqlQuery(Object val, GraphQLScalarType graphQLScalarType) throws GraphQLRequestExecutionException {
 		if (val == null) {
 			return null;
 		} else if (val instanceof java.util.List) {
-			return getListValue((List<?>) val);
+			return getListValue((List<?>) val, graphQLScalarType);
 		} else if (graphQLScalarType != null) {
 			Object ret = graphQLScalarType.getCoercing().serialize(val);
 			if (ret instanceof String)
@@ -242,11 +246,11 @@ public class InputParameter {
 	 * @throws NullPointerException
 	 *             If lst is null
 	 */
-	private String getListValue(List<?> list) throws GraphQLRequestExecutionException {
+	private String getListValue(List<?> list, GraphQLScalarType graphQLScalarType) throws GraphQLRequestExecutionException {
 		StringBuilder result = new StringBuilder("[");
 		for (int index = 0; index < list.size(); index++) {
 			Object obj = list.get(index);
-			result.append(this.getValueForGraphqlQuery(obj));
+			result.append(this.getValueForGraphqlQuery(obj, graphQLScalarType));
 			if (index < list.size() - 1) {
 				result.append(",");
 			}
@@ -275,7 +279,7 @@ public class InputParameter {
 
 				result.append(field.getName());
 				result.append(": ");
-				result.append(getValueForGraphqlQuery(val));
+				result.append(getValueForGraphqlQuery(val, graphqlClientUtils.getGraphQLCustomScalarType(field)));
 
 				separator = ", ";
 			}

--- a/graphql-java-runtime/src/test/java/com/graphql_java_generator/client/GraphqlClientUtilsTest.java
+++ b/graphql-java-runtime/src/test/java/com/graphql_java_generator/client/GraphqlClientUtilsTest.java
@@ -5,11 +5,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Field;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.graphql_java_generator.client.domain.forum.CustomScalarRegistryInitializer;
+import com.graphql_java_generator.client.domain.forum.Post;
+import com.graphql_java_generator.client.domain.forum.PostInput;
 import com.graphql_java_generator.client.domain.starwars.Character;
 import com.graphql_java_generator.client.domain.starwars.CharacterImpl;
 import com.graphql_java_generator.client.domain.starwars.Episode;
@@ -18,6 +22,8 @@ import com.graphql_java_generator.client.domain.starwars.QueryType;
 import com.graphql_java_generator.client.domain.starwars.ScalarTest;
 import com.graphql_java_generator.exception.GraphQLRequestExecutionException;
 import com.graphql_java_generator.exception.GraphQLRequestPreparationException;
+
+import graphql.schema.GraphQLScalarType;
 
 class GraphqlClientUtilsTest {
 
@@ -253,4 +259,33 @@ class GraphqlClientUtilsTest {
 		assertEquals(Episode.JEDI, map.get("param2"));
 		assertEquals("a String", map.get("param3"));
 	}
+
+	@Test
+	void test_getGraphQLScalarType() throws Exception {
+		// Given
+		new CustomScalarRegistryInitializer().initCustomScalarRegistry();
+
+		// When
+		Field field =  Post.class.getDeclaredField( "date" );
+
+		GraphQLScalarType graphQlScalarType = graphqlClientUtils.getGraphQLCustomScalarType( field );
+
+		// Then
+		assertNotNull( graphQlScalarType );
+	}
+
+	@Test
+	void test_getGraphQLScalarTypeGivenInputPojo() throws Exception {
+		// Given
+		new CustomScalarRegistryInitializer().initCustomScalarRegistry();
+
+		// When
+		Field field =  PostInput.class.getDeclaredField( "from" );
+
+		GraphQLScalarType graphQlScalarType = graphqlClientUtils.getGraphQLCustomScalarType( field );
+
+		// Then
+		assertNotNull( graphQlScalarType );
+	}
+
 }

--- a/graphql-java-runtime/src/test/java/com/graphql_java_generator/client/domain/forum/Post.java
+++ b/graphql-java-runtime/src/test/java/com/graphql_java_generator/client/domain/forum/Post.java
@@ -3,7 +3,6 @@ package com.graphql_java_generator.client.domain.forum;
 import java.util.Date;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.graphql_java_generator.annotation.GraphQLCustomScalar;
 import com.graphql_java_generator.annotation.GraphQLNonScalar;
 import com.graphql_java_generator.annotation.GraphQLScalar;
 
@@ -18,7 +17,7 @@ public class Post {
 	String id;
 
 	@JsonDeserialize(using = CustomScalarDeserializerDate.class)
-	@GraphQLCustomScalar(graphQLTypeName = "Date", javaClass = Date.class)
+	@GraphQLScalar(graphQLTypeName = "Date", javaClass = Date.class)
 	Date date;
 
 	@GraphQLNonScalar(graphQLTypeName = "Member", javaClass = Member.class)

--- a/graphql-java-runtime/src/test/java/com/graphql_java_generator/client/domain/forum/PostInput.java
+++ b/graphql-java-runtime/src/test/java/com/graphql_java_generator/client/domain/forum/PostInput.java
@@ -1,5 +1,7 @@
 package com.graphql_java_generator.client.domain.forum;
 
+import java.util.Date;
+import java.util.List;
 import java.util.UUID;
 
 import com.graphql_java_generator.annotation.GraphQLInputType;
@@ -20,6 +22,12 @@ public class PostInput {
 	@GraphQLNonScalar(graphQLTypeName = "TopicPostInput", javaClass = TopicPostInput.class)
 	TopicPostInput input;
 
+	@GraphQLScalar(graphQLTypeName = "Date", javaClass = Date.class)
+	Date from;
+
+	@GraphQLScalar(graphQLTypeName = "Date", javaClass = Date.class)
+	List<Date> in;
+
 	public void setTopicId(UUID topicId) {
 		this.topicId = topicId;
 	}
@@ -36,8 +44,24 @@ public class PostInput {
 		return input;
 	}
 
+	public Date getFrom() {
+		return from;
+	}
+
+	public void setFrom( Date from ) {
+		this.from = from;
+	}
+
+	public List<Date> getIn() {
+		return in;
+	}
+
+	public void setIn( List<Date> in ) {
+		this.in = in;
+	}
+
 	@Override
 	public String toString() {
-		return "PostInput {" + "topicId: " + topicId + ", " + "input: " + input + "}";
+		return "PostInput {" + "topicId: " + topicId + ", " + "input: " + input + ", " + "from: " + from + ", " + "in: " + in + "}";
 	}
 }

--- a/graphql-maven-plugin-logic/src/main/java/com/graphql_java_generator/plugin/DocumentParser.java
+++ b/graphql-maven-plugin-logic/src/main/java/com/graphql_java_generator/plugin/DocumentParser.java
@@ -794,9 +794,16 @@ public class DocumentParser {
 	 * @param field
 	 */
 	void addFieldAnnotationForClientMode(Field field) {
+		String contentAs = null;
+		String using = null;
 		if (field.isList()) {
-			((FieldImpl) field).addAnnotation(
-					"@JsonDeserialize(contentAs = " + field.getType().getConcreteClassSimpleName() + ".class)");
+			contentAs = field.getType().getConcreteClassSimpleName() + ".class";
+		}
+		if (field.getType().isCustomScalar()) {
+				using = "CustomScalarDeserializer" + field.getType().getConcreteClassSimpleName() + ".class";
+		}
+		if (contentAs != null || using != null) {
+			( (FieldImpl) field ).addAnnotation( buildJsonDeserializeAnnotation(contentAs, using) );
 		}
 
 		addFieldAnnotationForBothClientAndServerMode(field);
@@ -976,6 +983,35 @@ public class DocumentParser {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Build an @JsonDeserialize annotation with one or more attributes
+	 * @param contentAs contentAs class name
+	 * @param using using class name
+	 * @return annotation string
+	 */
+	private String buildJsonDeserializeAnnotation( String contentAs, String using) {
+		StringBuffer annotationBuf = new StringBuffer(  );
+		annotationBuf.append( "@JsonDeserialize(" );
+		boolean addComma = false;
+		if (contentAs != null) {
+			annotationBuf
+				 .append( "contentAs = " )
+				 .append( contentAs );
+			addComma = true;
+		}
+
+		if (using != null) {
+			if (addComma) {
+				annotationBuf.append( ", " );
+			}
+			annotationBuf
+				 .append( "using = " )
+				 .append( using );
+		}
+		annotationBuf.append( ")" );
+		return annotationBuf.toString();
 	}
 
 }

--- a/graphql-maven-plugin-logic/src/main/resources/templates/object_type.vm.java
+++ b/graphql-maven-plugin-logic/src/main/resources/templates/object_type.vm.java
@@ -63,4 +63,25 @@ public class ${object.name} #if($object.implementz.size()>0)implements #foreach(
 #end
         		+ "}";
     }
+
+    /**
+	 * Enum of field names
+	 */
+	 public static enum Field {
+#foreach ($field in $object.fields)
+		${field.pascalCaseName}("${field.name}")#if($foreach.hasNext),
+#end
+#end;
+
+		private String fieldName;
+
+		Field(String fieldName) {
+			this.fieldName = fieldName;
+		}
+
+		public String getFieldName() {
+			return fieldName;
+		}
+
+	}
 }


### PR DESCRIPTION
Hi Etienne, here is a new PR to add support for custom scalars as fields within input types which are not currently being serialised correctly when the input type is supplied as a single bind parameter.

I've also added the generation of a Field enum in each object POJO to give compile time literals for field names which are useful when composing queries using the builders.