### PR TITLE
Fixed error for Java 8 compilation.

### DIFF
--- a/graphql-maven-plugin-samples/graphql-maven-plugin-samples-allGraphQLCases-server/src/main/java/org/allGraphQLCases/server/impl/DataFetchersDelegateMyQueryTypeImpl.java
+++ b/graphql-maven-plugin-samples/graphql-maven-plugin-samples-allGraphQLCases-server/src/main/java/org/allGraphQLCases/server/impl/DataFetchersDelegateMyQueryTypeImpl.java
@@ -130,7 +130,7 @@ public class DataFetchersDelegateMyQueryTypeImpl implements DataFetchersDelegate
 		Class<? extends T> clazz;
 		try {
 			clazz = (Class<? extends T>) getClass().getClassLoader()
-					.loadClass(t.getPackageName() + "." + simpleClassname);
+					.loadClass(t.getPackage().getName() + "." + simpleClassname);
 		} catch (RuntimeException | ClassNotFoundException e) {
 			throw new RuntimeException(e.getMessage(), e);
 		}


### PR DESCRIPTION
 Class.getPackageName was introduced in Java 9 but project build is configured for Java 8