### PR TITLE
Enhances in Maven configuration to make easier samples projects import into IDE

### DIFF
--- a/graphql-maven-plugin-samples/graphql-maven-plugin-samples-Forum-client/pom.xml
+++ b/graphql-maven-plugin-samples/graphql-maven-plugin-samples-Forum-client/pom.xml
@@ -12,11 +12,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>build-helper-maven-plugin</artifactId>
-				<inherited>true</inherited>
-			</plugin>											
-			<plugin>
 				<groupId>com.graphql-java-generator</groupId>
 				<artifactId>graphql-maven-plugin</artifactId>
 				<executions>
@@ -37,6 +32,11 @@
 						</customScalar>
 					</customScalars>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<inherited>true</inherited>
 			</plugin>
 			<plugin>
 				<!-- Execution of the integration tests -->

--- a/graphql-maven-plugin-samples/graphql-maven-plugin-samples-Forum-client/pom.xml
+++ b/graphql-maven-plugin-samples/graphql-maven-plugin-samples-Forum-client/pom.xml
@@ -12,6 +12,11 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<inherited>true</inherited>
+			</plugin>											
+			<plugin>
 				<groupId>com.graphql-java-generator</groupId>
 				<artifactId>graphql-maven-plugin</artifactId>
 				<executions>

--- a/graphql-maven-plugin-samples/graphql-maven-plugin-samples-Forum-server/pom.xml
+++ b/graphql-maven-plugin-samples/graphql-maven-plugin-samples-Forum-server/pom.xml
@@ -14,11 +14,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>build-helper-maven-plugin</artifactId>
-				<inherited>true</inherited>
-			</plugin>											
-			<plugin>
 				<!-- Needed to properly package the jar or war, so that spring can link all resources together -->
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
@@ -48,6 +43,11 @@
 					</customScalars>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<inherited>true</inherited>
+			</plugin>			
 			<plugin>
 				<!-- We don't want to spam the repository with test/sample artefacts -->
 				<artifactId>maven-deploy-plugin</artifactId>

--- a/graphql-maven-plugin-samples/graphql-maven-plugin-samples-Forum-server/pom.xml
+++ b/graphql-maven-plugin-samples/graphql-maven-plugin-samples-Forum-server/pom.xml
@@ -14,6 +14,11 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<inherited>true</inherited>
+			</plugin>											
+			<plugin>
 				<!-- Needed to properly package the jar or war, so that spring can link all resources together -->
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/graphql-maven-plugin-samples/graphql-maven-plugin-samples-StarWars-client/pom.xml
+++ b/graphql-maven-plugin-samples/graphql-maven-plugin-samples-StarWars-client/pom.xml
@@ -12,11 +12,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>build-helper-maven-plugin</artifactId>
-				<inherited>true</inherited>
-			</plugin>											
-			<plugin>
 				<groupId>com.graphql-java-generator</groupId>
 				<artifactId>graphql-maven-plugin</artifactId>
 				<executions>
@@ -30,6 +25,11 @@
 					<mode>client</mode>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<inherited>true</inherited>
+			</plugin>			
 			<plugin>
 				<!-- Execution of the integration tests -->
 				<groupId>org.apache.maven.plugins</groupId>

--- a/graphql-maven-plugin-samples/graphql-maven-plugin-samples-StarWars-client/pom.xml
+++ b/graphql-maven-plugin-samples/graphql-maven-plugin-samples-StarWars-client/pom.xml
@@ -12,6 +12,11 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<inherited>true</inherited>
+			</plugin>											
+			<plugin>
 				<groupId>com.graphql-java-generator</groupId>
 				<artifactId>graphql-maven-plugin</artifactId>
 				<executions>

--- a/graphql-maven-plugin-samples/graphql-maven-plugin-samples-StarWars-server/pom.xml
+++ b/graphql-maven-plugin-samples/graphql-maven-plugin-samples-StarWars-server/pom.xml
@@ -14,11 +14,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>build-helper-maven-plugin</artifactId>
-				<inherited>true</inherited>
-			</plugin>											
-			<plugin>
 				<!-- Needed to properly package the jar or war, so that spring can link all resources together -->
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
@@ -40,6 +35,11 @@
 					<packageName>com.graphql_java_generator.samples.server</packageName>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<inherited>true</inherited>
+			</plugin>			
 			<plugin>
 				<!-- We don't want to spam the repository with test/sample artefacts -->
 				<artifactId>maven-deploy-plugin</artifactId>

--- a/graphql-maven-plugin-samples/graphql-maven-plugin-samples-StarWars-server/pom.xml
+++ b/graphql-maven-plugin-samples/graphql-maven-plugin-samples-StarWars-server/pom.xml
@@ -14,6 +14,11 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<inherited>true</inherited>
+			</plugin>											
+			<plugin>
 				<!-- Needed to properly package the jar or war, so that spring can link all resources together -->
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/graphql-maven-plugin-samples/graphql-maven-plugin-samples-allGraphQLCases-client/pom.xml
+++ b/graphql-maven-plugin-samples/graphql-maven-plugin-samples-allGraphQLCases-client/pom.xml
@@ -12,11 +12,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>build-helper-maven-plugin</artifactId>
-				<inherited>true</inherited>
-			</plugin>											
-			<plugin>
 				<groupId>com.graphql-java-generator</groupId>
 				<artifactId>graphql-maven-plugin</artifactId>
 				<executions>
@@ -47,6 +42,11 @@
 						</customScalar>
 					</customScalars>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<inherited>true</inherited>
 			</plugin>
 			<plugin>
 				<!-- Execution of the integration tests -->

--- a/graphql-maven-plugin-samples/graphql-maven-plugin-samples-allGraphQLCases-client/pom.xml
+++ b/graphql-maven-plugin-samples/graphql-maven-plugin-samples-allGraphQLCases-client/pom.xml
@@ -12,6 +12,11 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<inherited>true</inherited>
+			</plugin>											
+			<plugin>
 				<groupId>com.graphql-java-generator</groupId>
 				<artifactId>graphql-maven-plugin</artifactId>
 				<executions>

--- a/graphql-maven-plugin-samples/graphql-maven-plugin-samples-allGraphQLCases-server/pom.xml
+++ b/graphql-maven-plugin-samples/graphql-maven-plugin-samples-allGraphQLCases-server/pom.xml
@@ -13,6 +13,11 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<inherited>true</inherited>
+			</plugin>									
+			<plugin>
 				<groupId>com.graphql-java-generator</groupId>
 				<artifactId>graphql-maven-plugin</artifactId>
 				<executions>

--- a/graphql-maven-plugin-samples/graphql-maven-plugin-samples-allGraphQLCases-server/pom.xml
+++ b/graphql-maven-plugin-samples/graphql-maven-plugin-samples-allGraphQLCases-server/pom.xml
@@ -13,11 +13,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>build-helper-maven-plugin</artifactId>
-				<inherited>true</inherited>
-			</plugin>									
-			<plugin>
 				<groupId>com.graphql-java-generator</groupId>
 				<artifactId>graphql-maven-plugin</artifactId>
 				<executions>
@@ -48,6 +43,11 @@
 						</customScalar>
 					</customScalars>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<inherited>true</inherited>
 			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>

--- a/graphql-maven-plugin-samples/pom.xml
+++ b/graphql-maven-plugin-samples/pom.xml
@@ -42,7 +42,7 @@
 				<executions>
 					<execution>
 						<id>add-source</id>
-						<phase>generate-resources</phase>
+						<phase>generate-sources</phase>
 						<goals>
 							<goal>add-source</goal>
 						</goals>

--- a/graphql-maven-plugin-samples/pom.xml
+++ b/graphql-maven-plugin-samples/pom.xml
@@ -35,6 +35,25 @@
 					<artifactId>graphql-maven-plugin</artifactId>
 					<version>${project.version}</version>
 				</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>3.0.0</version>
+				<executions>
+					<execution>
+						<id>add-source</id>
+						<phase>generate-resources</phase>
+						<goals>
+							<goal>add-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>${project.build.directory}/generated-sources/graphql-maven-plugin</source>
+							</sources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>							
 			</plugins>
 		</pluginManagement>
 		<plugins>


### PR DESCRIPTION
Added **org.codehaus.mojo:build-helper-maven-plugin** to samples projects pom so generated-sources directory is marked add source directory when samples projects are imported into the IDE
Parent pom has the complete configuration and modules just inherit the configuration from the parent