### PR TITLE
Make configurable to copy Graphql java runtime classes on code genreation

### DIFF
--- a/graphql-maven-plugin-logic/src/main/java/com/graphql_java_generator/plugin/CodeGenerator.java
+++ b/graphql-maven-plugin-logic/src/main/java/com/graphql_java_generator/plugin/CodeGenerator.java
@@ -134,7 +134,9 @@ public class CodeGenerator {
 			break;
 		}
 
-		copyGraphQLJavaSources();
+		if(pluginConfiguration.isCopyGraphQLJavaSources()) {
+			copyGraphQLJavaSources();
+		}
 
 		return i;
 

--- a/graphql-maven-plugin-logic/src/main/java/com/graphql_java_generator/plugin/PluginConfiguration.java
+++ b/graphql-maven-plugin-logic/src/main/java/com/graphql_java_generator/plugin/PluginConfiguration.java
@@ -5,7 +5,11 @@ package com.graphql_java_generator.plugin;
 
 import java.io.File;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
+import org.apache.commons.lang.StringUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -105,6 +109,12 @@ public interface PluginConfiguration {
 	/** The folder where the generated classes will be generated */
 	public File getTargetSourceFolder();
 
+	/**
+	 * Returns true if shall copy graphql sources (graphql-java-runtime) source code
+	 * @return
+	 */
+	public boolean isCopyGraphQLJavaSources();
+
 	/** Logs all the configuration parameters, in the debug level */
 	default public void logConfiguration() {
 		if (getLog().isDebugEnabled()) {
@@ -118,6 +128,7 @@ public interface PluginConfiguration {
 			getLog().debug("  SourceEncoding: " + getMode());
 			getLog().debug("  TargetClassFolder: " + getTargetClassFolder());
 			getLog().debug("  TargetSourceFolder: " + getTargetSourceFolder());
+			getLog().debug("  CopyGraphQLJavaSources: " + isCopyGraphQLJavaSources());
 		}
 	}
 }

--- a/graphql-maven-plugin-logic/src/test/java/com/graphql_java_generator/plugin/test/helper/MavenTestHelper.java
+++ b/graphql-maven-plugin-logic/src/test/java/com/graphql_java_generator/plugin/test/helper/MavenTestHelper.java
@@ -15,6 +15,8 @@ public class MavenTestHelper {
 
 	final static String MODULE_NAME = "graphql-maven-plugin";
 	final static String TARGET_SOURCE_FOLDER = "/target/junittest/UNIT_TEST_NAME/generated-src";
+	final static String RUNTIME_BASE_PACKAGE_FOLDER = "com/graphql_java_generator";
+	final static String TESTING_RUNTIME_SOURCE_FILE = "target/test-classes/graphql-java-runtime-sources.jar"; 
 
 	/**
 	 * Returns the root path for this module. The issue here, is that the current path is the root path for this module,
@@ -44,6 +46,23 @@ public class MavenTestHelper {
 	 */
 	public File getTargetSourceFolder(String unitTestName) {
 		return new File(getModulePathFile(), TARGET_SOURCE_FOLDER.replace("UNIT_TEST_NAME", unitTestName));
+	}
+	
+	/**
+	 * Gets the base folder for runtime classes calculated for the given test name  
+	 * @param unitTestName
+	 * @return
+	 */
+	public File getTargetRuntimeClassesBaseSourceFolder(String unitTestName) {
+		return new File(getTargetSourceFolder(unitTestName), RUNTIME_BASE_PACKAGE_FOLDER);
+	}
+	
+	/**
+	 * Resolve the file for runtime sources to be used in IDE tests related to code generation 
+	 * @return
+	 */
+	public File getTestRutimeSourcesJarFile() {
+		return new File(TESTING_RUNTIME_SOURCE_FILE);
 	}
 
 	/**

--- a/graphql-maven-plugin-logic/src/test/java/com/graphql_java_generator/plugin/test/helper/PluginConfigurationTestHelper.java
+++ b/graphql-maven-plugin-logic/src/test/java/com/graphql_java_generator/plugin/test/helper/PluginConfigurationTestHelper.java
@@ -34,6 +34,7 @@ public class PluginConfigurationTestHelper implements PluginConfiguration {
 	public String sourceEncoding = null;
 	public File targetClassFolder = null;
 	public File targetSourceFolder = null;
+	public boolean copyGraphQLJavaSources = true;
 
 	/**
 	 * @param caller
@@ -46,6 +47,11 @@ public class PluginConfigurationTestHelper implements PluginConfiguration {
 	@Override
 	public boolean getGenerateJPAAnnotation() {
 		return true;
+	}
+
+	@Override
+	public boolean isCopyGraphQLJavaSources() {
+		return copyGraphQLJavaSources;
 	}
 
 }

--- a/graphql-maven-plugin/src/main/java/com/graphql_java_generator/mavenplugin/GraphqlMavenPlugin.java
+++ b/graphql-maven-plugin/src/main/java/com/graphql_java_generator/mavenplugin/GraphqlMavenPlugin.java
@@ -125,6 +125,12 @@ public class GraphqlMavenPlugin extends AbstractMojo {
 	@Parameter(defaultValue = "${project}", readonly = true, required = true)
 	MavenProject project;
 
+	/**
+	 * Flag to enable copy sources for graphql-java-runtime library to target source code directory
+	 */
+	@Parameter(property = "com.graphql_java_generator.mavenplugin.copyGraphQLJavaSources", defaultValue = "true")	
+	boolean copyGraphQLJavaSources;
+
 	/** {@inheritDoc} */
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {

--- a/graphql-maven-plugin/src/main/java/com/graphql_java_generator/mavenplugin/PluginConfigurationImpl.java
+++ b/graphql-maven-plugin/src/main/java/com/graphql_java_generator/mavenplugin/PluginConfigurationImpl.java
@@ -99,4 +99,9 @@ public class PluginConfigurationImpl implements PluginConfiguration {
 		return new File(getTargetFolder(), mojo.targetSourceFolder);
 	}
 
+	@Override
+	public boolean isCopyGraphQLJavaSources() {
+		return this.mojo.copyGraphQLJavaSources;
+	}
+
 }

--- a/src/site/apt/runtimeclasses.apt.vm
+++ b/src/site/apt/runtimeclasses.apt.vm
@@ -1,0 +1,92 @@
+               ------------------------------------------
+               GraphQL Maven Plugin (client mode)
+               ------------------------------------------
+               ------------------------------------------
+               ------------------------------------------
+
+
+Runtime Classes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+%{toc}
+	
+* {Presentation}
+~~~~~~~~~~~~~~~~~~~
+
+  As the result of the execution of graphql-maven-plugin:graphql two type of source code is generated
+  
+  * The Query, Mutation and POJOs classes
+  
+  * All the necessary runtime classes that do not depend on the schema and support the client execution
+  
+  []
+  
+  The runtime classes are copied as source code so, your project, when it runs, doesn't depend on any external dependency from graphql-java-generator. 
+  But if for any reason you don't what the the runtime classes in your generated source code (and you just want to add them as a dependency) it is possible to customize
+  the plugin execution so they are not generated
+  
+  
+
+* {How to use the configure source code generation to no include runtime classes?}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  To avoid the generation of runtime classes you can use the parameter <<copyGraphQLJavaSources>> (-Dcom.graphql_java_generator.mavenplugin.copyGraphQLJavaSources)
+  If copyGraphQLJavaSources is "false", then the runtime classes won't be generated. By default, the parameter value is "true"
+  
+  Here there's an exmaple of plugin configuration to not generate runtime classes
+
++--------------------------------------------------------------------------------------------
+<project ...>
+...
+
+	<build>
+		<plugins>
+...
+			<plugin>
+				<groupId>com.graphql-java-generator</groupId>
+				<artifactId>graphql-maven-plugin</artifactId>
+				<version>${lastReleasedVersion}</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>graphql</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<mode>client</mode>
+					<packageName>my.target.package</packageName>
+					<copyGraphQLJavaSources>false</copyGraphQLJavaSources>					
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+...
+</project>
++--------------------------------------------------------------------------------------------
+
+  Remember that it you decide not to generate runtime classes, <<com.graphql-java-generator:graphql-java-runtime:${lastReleasedVersion}>> shall be somehow included in your classpath
+  You may use <<com.graphql-java-generator:graphql-java-runtime:${lastReleasedVersion}>> artifact as a dependency in your project to include graphql-java-runtime in your classpath 
+  
++--------------------------------------------------------------------------------------------
+<project ...>
+...
+  	<dependencies>
+  		...
+		<dependency>
+			<groupId>com.graphql-java-generator</groupId>
+			<artifactId>graphql-java-runtime</artifactId>
+			<version>${lastReleasedVersion}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.graphql-java-generator</groupId>
+					<artifactId>graphql-java-server-dependencies</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+  		...
+  	</dependencies>
+...
+</project>
++--------------------------------------------------------------------------------------------
+  

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -24,6 +24,7 @@
 		<menu name="Client mode">
 			<item name="Plugin usage" href="client.html" />
 			<item name="Introspection" href="introspection.html" />
+			<item name="Runtime Classes" href="runtimeclasses.html" />
 		</menu>
 
 		<menu name="Server mode">


### PR DESCRIPTION
Is some cases for cliente code generated may be useful not to copy graphql-java-runtime sources and instead use the library as a dependency. And it will be nice to do it in the Maven plugin configuration

The following changes have been added:
- Modified **GraphqlMavenPlugin** with new configuration property **"copyGrahQLJavaSources"** for enabling copy of graphql java runtime sources when generating sources. The property by default is **"true"** so if not configured the code generation behaves as how it is today. **PluginConfiguration** interface and **PluginConfigurationImpl** has been adapted to hold this new configuration parameter
- Added tests to **CodeGeneratorTest** with two new test cases for testing copy and not copy configuration. To facilitate test execution on IDE, some features have been added to build a mock graphql-java-runtime-sources.jar to test generateCode method invocation. **PluginConfigurationTestHelper** has been modified to hold new copyGraphQLJavaSources parameter and MavenTestHelper has been completed with helper methods to resolve directories for copied sources