### PR TITLE
Modifying the getGetter method to accept reserved keywords

### DIFF
--- a/graphql-java-common-runtime/src/main/java/com/graphql_java_generator/util/GraphqlUtils.java
+++ b/graphql-java-common-runtime/src/main/java/com/graphql_java_generator/util/GraphqlUtils.java
@@ -649,8 +649,15 @@ public class GraphqlUtils {
 				method = clazz.getMethod(getterMethodName);
 			} catch (NoSuchMethodException e) {
 				// For the boolean fields, the getter may be named isProperty. Let's try that:
-				if (field.getType().equals(boolean.class) || field.getType().equals(Boolean.class)) {
+				if (field.getType().equals(boolean.class) || field.getType().equals(Boolean.class) && field.getName()
+								.startsWith("is")) {
 					getterMethodName = "is" + getPascalCase(field.getName());
+					method = clazz.getMethod(getterMethodName);
+				}
+				// For the fields conflicting with reserved keywords and generated with an underscore (_), the getter may be named _Property. Let's try that:
+				else if (field.getName().startsWith("_")) {
+					String sanitizedField = field.getName().substring(1);
+					getterMethodName = "get" + getPascalCase(sanitizedField);
 					method = clazz.getMethod(getterMethodName);
 				} else {
 					throw e;
@@ -659,7 +666,7 @@ public class GraphqlUtils {
 			// The return type must be the same as the field's class
 			if (field.getType() != method.getReturnType()) {
 				throw new RuntimeException("The getter '" + getterMethodName + "' and the field '" + field.getName()
-						+ "' of the class " + clazz.getName() + " should be of the same type");
+								+ "' of the class " + clazz.getName() + " should be of the same type");
 			}
 
 			return method;


### PR DESCRIPTION
At runtime, the getGetter method does not support reserved keywords like default, etc. Currently it sends the "NoSuchMethodException" at runtime when properly fields are about to be serialized.

For complete information, please have a look at my comment on a previous PR:
https://github.com/graphql-java-generator/graphql-maven-plugin-project/issues/166

Version affected: 1.18.9

pom.xml
```
        <dependency>
            <groupId>com.graphql-java-generator</groupId>
            <artifactId>graphql-maven-plugin</artifactId>
            <version>1.18.9</version>
        </dependency>
```