### PR TITLE
Better generation for parameters

### DIFF
--- a/graphql-java-client-runtime/src/main/java/com/graphql_java_generator/client/request/AbstractGraphQLRequest.java
+++ b/graphql-java-client-runtime/src/main/java/com/graphql_java_generator/client/request/AbstractGraphQLRequest.java
@@ -484,8 +484,15 @@ public abstract class AbstractGraphQLRequest {
 				} else {
 					mandatory = false;
 				}
+				
+				Object defaultValue = null;
+				if (qt.checkNextToken("=")) {
+				    token = qt.nextToken();
+				    token = qt.nextToken();
+				    defaultValue = token;
+				}
 
-				inputParameters.add(InputParameter.newGraphQLVariableParameter(schema, name, graphQLTypeName, mandatory,
+				inputParameters.add(InputParameter.newGraphQLVariableParameter(schema, name, defaultValue, graphQLTypeName, mandatory,
 						listDepth, itemMandatory));
 				// The next token should be either the end of parameters (with a ')') or a name
 				step = Step.NAME;
@@ -882,6 +889,11 @@ public abstract class AbstractGraphQLRequest {
 				//////////////////////////////////////////////////////////////////////
 				// And the variable value list (for the json variables field)
 				payload.variables.put(param.getBindParameterName(), param.getValueForGraphqlQuery(params));
+				
+				if (param.getValue() != null) {
+				    sbGraphQLVariables.append("=");
+				    sbGraphQLVariables.append(param.getValue());
+				}
 
 				separator = ","; //$NON-NLS-1$
 			}


### PR DESCRIPTION
## Parameters will null values

A query like this
```
query HomeQueryRendererAllPostQuery($first: Int, $last: Int) {
  viewer {
    announcements(first: $first, last: $last) {
      edges {
...
```

with parameters `first = 1, last = null` would generate

```
query HomeQueryRendererAllPostQuery($first: Int, $last: Int) {
  viewer {
    announcements(first: $first) {
      edges {
```

leading to errors with backends checking parameters are used; this is fixed here.

## Parameters with default values

Also, queries with default parameters like this

```
query HomeQueryRendererAllPostQuery($first: Int, $last: Int = 1) {
  viewer {
    announcements(first: $first, last: $last) {
      edges {
```

were not supported; this too has been added.